### PR TITLE
Update dataset on change rather than data

### DIFF
--- a/src/chart.component.ts
+++ b/src/chart.component.ts
@@ -31,10 +31,20 @@ export class ChartComponent implements OnInit, OnChanges {
       if (changes['type'] || changes['options']) {
         this.create();
       } else if (changes['data']) {
-        let currentValue = changes['data'].currentValue;
-        ['datasets', 'labels', 'xLabels', 'yLabels'].forEach(property => {
+        const currentValue = changes['data'].currentValue;
+        ['labels', 'xLabels', 'yLabels'].forEach(property => {
           this.chart.data[property] = currentValue[property];
-        })
+        });
+        if (currentValue.datasets) {
+          for (let i = 0; i < currentValue.datasets.length; i++) {
+            if (!this.chart.data.datasets[i].data || this.chart.data.datasets[i].data.length < 1) {
+              this.chart.data.datasets[i] = currentValue.datasets[i];
+            } else {
+              this.chart.data.datasets[i].data = currentValue.datasets[i].data;
+            }
+          }
+        }
+
         this.chart.update();
       }
     }


### PR DESCRIPTION
Issue #48 

**Previous Behavior** 

When updating data the chart animation transitions from the Y axis as it would when initially binding data to the chart. 

![chartbefore](https://user-images.githubusercontent.com/5644228/50539539-e310fb00-0b79-11e9-9fbb-bbb844fad89e.gif)

**Expected Behavior**

When updating data the chart animation should transition from the current position, not the y axis.

![chartafter](https://user-images.githubusercontent.com/5644228/50539557-2ff4d180-0b7a-11e9-83ac-c495e1b22005.gif)

**Cause**

Instead of setting the updated data on the existing dataset, a new dataset is created so the transition always appears as it does on the initial bind.

**Solution**

This PR addresses this problem by updating exist data sets, if they exist and have data.
 