### PR TITLE
Change `chart.js` to a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start": "webpack-dev-server --progress --profile --colors --watch --display-error-details --display-cached --content-base dev/"
   },
   "peerDependencies": {
-    "chart.js": ">= 2.7 < 3",
+    "chart.js": ">= 2 < 3",
     "@angular/common": ">=4.0.0 || ^2.0.0",
     "@angular/compiler": ">=4.0.0 || ^2.0.0",
     "@angular/core": ">=4.0.0 || ^2.0.0"

--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
     "start": "webpack-dev-server --progress --profile --colors --watch --display-error-details --display-cached --content-base dev/"
   },
   "peerDependencies": {
+    "chart.js": ">= 2.7 < 3",
     "@angular/common": ">=4.0.0 || ^2.0.0",
     "@angular/compiler": ">=4.0.0 || ^2.0.0",
     "@angular/core": ">=4.0.0 || ^2.0.0"
   },
   "dependencies": {
-    "chart.js": "^2.3.0"
   },
   "author": "Chen, Yi-Cyuan <emn178@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This allows the user to install the preferred chart.js version

For example, I needed some bugfixes from upstream.

The user would obviously need to install `chart.js` himself, so this probably is a breaking change?

---

Edit:

It doesn't seem like this is going to be fixed.

For anyone looking for a work-around - I've started using `yarn` over `npm`, because it can do something like this, called [`dependency resolution`](https://yarnpkg.com/lang/en/docs/selective-version-resolutions/):

`package.json`

```json
{
    "dependencies": {
		"angular2-chartjs": "^0.5.1"
	},
    "resolutions": {
        "angular2-chartjs/chart.js": "^2.8.0"
    }
}
```

as you can see - you can modify deep dependencies' versions and such.

Once again - check [the documentation](https://yarnpkg.com/lang/en/docs/selective-version-resolutions/).

Also, I'm aware that `npm` has a package [`npm-force-resolutions`](https://www.npmjs.com/package/npm-force-resolutions), but this feature is not natively supported by `npm` itself. And `yarn` turned out pretty cool for me, so I didn't mind the switch.

P.S. - I've even tried generating patches for the deep dependencies' `package.json`, but it turns out that `npm` adds a lot of junk that makes the patches unusable, since the changed content differs everytime you re-install dependencies, like after cloning the project. See https://github.com/ds300/patch-package/issues/150 for reference.

(
I've even tried making a custom `postinstall` script for npm to run, but turns out 
that npm only applies the modifications to `package-lock.json` file only *AFTER* the whole installation, including the `postinstall` script, has finished, effectively meaning that's it's either impossible or really hard/complicated/not worth to do.
)